### PR TITLE
Adds `assertEqual` as testing operation

### DIFF
--- a/scalaz/src/main/scala/TestingOps.scala
+++ b/scalaz/src/main/scala/TestingOps.scala
@@ -25,6 +25,20 @@ trait TestingOps{
     def isEqual(a: A)(implicit F: Functor[P]): P[Boolean] =
       F.map(self)(_ == a)
 
+    case class NotError[A](value: A, e: Throwable) extends RuntimeException
+    case class OtherError(error: Throwable, e: Throwable) extends RuntimeException{
+      override def toString() = s"OtherError($error,$e)"
+    }
+
+    def assertError(e: Throwable)(implicit ME: MonadError[P, Throwable]): P[Unit] =
+      (self >>= { a =>
+        (NotError(a,e): Throwable).raiseError[P,Unit]
+      }).handleError{
+        case `e` => ().point[P]
+        case error =>
+        (OtherError(error,e): Throwable).raiseError[P,Unit]
+      }
+
     case class NotEqualTo[A](a1: A, a2: A) extends RuntimeException
 
     def assertEqual(a1: A)(implicit ME: MonadError[P, Throwable]): P[Unit] =

--- a/scalaz/src/test/scala/SpecScalatest.scala
+++ b/scalaz/src/test/scala/SpecScalatest.scala
@@ -8,13 +8,13 @@ import puretest.{Filter => TestFilter}, scalatestImpl._
 trait SpecScalatest[P[_]] extends Spec[P]{ self : FunSpec with Matchers =>
 
   implicit val Te: StateTester[P,Int,Throwable]
-  
+
   // Tests
 
   import ProgramStateMatchers.Syntax._
 
   describe("beSatisfied for Boolean program"){
-    
+
     it("should work for working programs returning true"){
       trueProgram should beSatisfied(from = 0)
     }
@@ -52,6 +52,28 @@ trait SpecScalatest[P[_]] extends Spec[P]{ self : FunSpec with Matchers =>
 
     it("should work for failing programs with handled errors"){
       failingProgramWithHandledError should runWithoutErrors(from = 0)
+    }
+  }
+
+  describe("assertError and assertEquals"){
+    it("should work for working programs"){
+      trueProgram.assertEqual(true) should runWithoutErrors(from = 0)
+      falseProgram.assertEqual(false) should runWithoutErrors(from = 0)
+      workingProgram.assertEqual(()) should runWithoutErrors(from = 0)
+    }
+
+    import sourcecode.{File,Line}
+
+    it("should work for failing programs at pattern matching"){
+      failingMatchBoolProgram.assertError(
+        puretest.Filter.LocationException("1",
+          (File("/Users/jserrano/Documents/puretest/scalaz/src/test/scala/Spec.scala"),Line(30)))
+      ) should runWithoutErrors(from = 0)
+
+      failingMatchProgram.assertError(
+        puretest.Filter.LocationException("1",
+          (File("/Users/jserrano/Documents/puretest/scalaz/src/test/scala/Spec.scala"),Line(35)))
+      ) should runWithoutErrors(from = 0)
     }
   }
 }


### PR DESCRIPTION
Adds `assertEqual` as an alternative to `isEqual`. This new method raises a `NonEqualTo` exception (which has been created for this purpose) as long as its parameter is not equal to the current value contained by the program. This methods works for "monad errors" whose error parameter is `Throwable`.

(*) UPDATE A running example can be found here: https://github.com/hablapps/stateless/pull/14/commits/bcc434b7dacd1100abe66ec9314af72a7926c8a4