### PR TITLE
Equal and Arbitrary instances for StateT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ lazy val commonSettings = Seq(
   // addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full),
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "3.0.0",
+    "org.scalacheck" %% "scalacheck" % "1.13.4",
     "com.lihaoyi" %% "sourcecode" % "0.1.3"),
   resolvers ++= Seq(
     "Speech repo - releases" at "http://repo.hablapps.com/releases"),

--- a/scalaz/src/main/scala/package.scala
+++ b/scalaz/src/main/scala/package.scala
@@ -1,6 +1,8 @@
 package org.hablapps
 
-package object puretest 
+package object puretest
   extends StateTMonadError
+  with StateTEqual
+  with StateTArbitrary
   with StateValidationMonad
   with TestingOps

--- a/scalaz/src/main/scala/utils/StateTArbitrary.scala
+++ b/scalaz/src/main/scala/utils/StateTArbitrary.scala
@@ -1,0 +1,24 @@
+package org.hablapps.puretest
+
+import org.scalacheck._
+
+import scalaz._, Scalaz._
+
+trait StateTArbitrary extends StateTArbitrary0 {
+
+  implicit def stateArbitrary[S, A](implicit
+      as: Arbitrary[S],
+      aa: Arbitrary[A],
+      cs: Cogen[S]): Arbitrary[State[S, A]] =
+    stateTArbitrary[Id, S, A]
+}
+
+trait StateTArbitrary0 {
+
+  implicit def stateTArbitrary[F[_], S, A](implicit
+      m: Monad[F],
+      as: Arbitrary[S],
+      afsa: Arbitrary[F[(S, A)]],
+      cs: Cogen[S]): Arbitrary[StateT[F, S, A]] =
+    Arbitrary(Gen.resultOf[S => F[(S, A)], StateT[F, S, A]](StateT.apply))
+}

--- a/scalaz/src/main/scala/utils/StateTEqual.scala
+++ b/scalaz/src/main/scala/utils/StateTEqual.scala
@@ -1,0 +1,29 @@
+package org.hablapps.puretest
+
+import org.scalacheck._
+
+import scalaz._, Scalaz._
+
+trait StateTEqual extends StateTEqual0 {
+
+  implicit def stateEqual[S, A](implicit
+      as: Arbitrary[S],
+      eq1: Equal[S],
+      eq2: Equal[A]): Equal[State[S, A]] =
+    stateTEqual[Id, S, A]
+}
+
+trait StateTEqual0 {
+
+  implicit def stateTEqual[F[_], S, A](implicit
+      m: Monad[F],
+      as: Arbitrary[S],
+      eq1: Equal[S],
+      eq2: Equal[A],
+      eq3: Equal[F[(S, A)]]): Equal[StateT[F, S, A]] =
+    Equal[StateT[F, S, A]] { (st1, st2) =>
+      Gen.listOfN(50, as.arbitrary).sample
+        .getOrElse(sys.error("could not generate arbitrary list of init states"))
+        .forall(s => st1(s) === st2(s))
+    }
+}

--- a/scalaz/src/main/scala/utils/StateTEqual.scala
+++ b/scalaz/src/main/scala/utils/StateTEqual.scala
@@ -21,7 +21,7 @@ trait StateTEqual0 {
       eq1: Equal[S],
       eq2: Equal[A],
       eq3: Equal[F[(S, A)]]): Equal[StateT[F, S, A]] =
-    Equal[StateT[F, S, A]] { (st1, st2) =>
+    Equal.equal[StateT[F, S, A]] { (st1, st2) =>
       Gen.listOfN(50, as.arbitrary).sample
         .getOrElse(sys.error("could not generate arbitrary list of init states"))
         .forall(s => st1(s) === st2(s))


### PR DESCRIPTION
Adds instances of `Equal` and `Arbitrary` typeclasses for `StateT`. This also includes bindings for `State`, to avoid `Id` inference troubles.

There's a hardcoded `50` in the `Equal` instance, that corresponds with the number of initial states to test against. It seems to be a nice number while running states on the JVM.

The `Arbitrary` instance has been implemented in terms of `Arbitrary[S => F[(S, A)]`. This solution seemed weird to me at the beginning, since I was firstly trying to combine `get`, `put` and `return` programs, but I think it's quite natural, `StateT` is just a wrapper for that kind of function!